### PR TITLE
Fixes in interface for magnetic mats and testing

### DIFF
--- a/irrep/bandstructure.py
+++ b/irrep/bandstructure.py
@@ -412,7 +412,7 @@ class BandStructure:
                 degen_thresh=degen_thresh,
                 refUC=self.spacegroup.refUC,
                 shiftUC=self.spacegroup.shiftUC,
-                symmetries_tables=self.spacegroup.symmetries_tables,
+                symmetries_tables=self.spacegroup.u_symmetries_tables,
                 save_wf=save_wf,
                 verbosity=verbosity,
                 calculate_traces=calculate_traces,
@@ -427,7 +427,7 @@ class BandStructure:
                 upper=upper,
                 num_bands=NBout,
                 RecLattice=self.RecLattice,
-                symmetries_SG=self.spacegroup.symmetries,
+                symmetries_SG=self.spacegroup.u_symmetries,
                 spinor=self.spinor,
                 kwargs_kpoint=self.kwargs_kpoint,
                 normalize=normalize,
@@ -703,7 +703,7 @@ class BandStructure:
         symop.show()
 
         # to do: allow for separation in terms of antiunitary symmetries
-        if isymop > self.spacegroup.order:
+        if isymop > len(self.spacegroup.u_symmetries):
             raise RuntimeError("Separation in terms of antiunitary symmetries "
                                "not implemented for now.")
 
@@ -954,7 +954,7 @@ class BandStructure:
         #  by the isym-th symmetry operation.
         #
         # This is consistent with w90 documentations, but seemd to be opposite to what pw2wannier90 does
-        symmetries = self.spacegroup.symmetries + self.spacegroup.au_symmetries
+        symmetries = self.spacegroup.symmetries
 
         kpoints_mod1 = UniqueListMod1(kpoints)
         assert len(kpoints_mod1) == len(kpoints)

--- a/irrep/kpoint.py
+++ b/irrep/kpoint.py
@@ -30,9 +30,6 @@ class Kpoint:
     traces (and irreps), for the separation of the band structure in terms of a 
     symmetry operation and for the calculation of the Zak phase.
 
-        symmetries=None,
-        symmetries_tables=None  # calculate_traces needs it
-
     Parameters
     ----------
     ik : int

--- a/irrep/tests/test_dmn.py
+++ b/irrep/tests/test_dmn.py
@@ -22,7 +22,7 @@ def check_Fe_qe(include_TR):
                                  unitary_params={"check_upper": False,
                                                  "waring_threshold":1e-3,
                                                  "error_threshold":1e-2}, )
-    print (f"number of symmetries: {bandstructure.spacegroup.order}")
+    print (f"number of symmetries: {bandstructure.spacegroup.size}")
     for a in data["d_band_blocks"][:1]:
         for b in a:
             for c in b:

--- a/irreptables/irreptables/__init__.py
+++ b/irreptables/irreptables/__init__.py
@@ -373,19 +373,16 @@ class IrrepTable:
                 assert str2bool(l[1]) == self.spinor
             elif l[0].lower() == "symmetries":
                 log_message("Reading symmetries from tables", v, 2)
-                symmetries = []
-                while len(symmetries) < self.nsym:
+                self.symmetries = []
+                while len(self.symmetries) < self.nsym:
                     l = lines.pop()
                     # logger.debug(l)
                     try:
-                        symmetries.append(SymopTable(l))
+                        self.symmetries.append(SymopTable(l))
                     except Exception as err:
                         logger.debug(err)
                         pass
                 break
-
-        self.symmetries = list(filter(lambda x: not x.time_reversal, symmetries))
-        self.au_symmetries = list(filter(lambda x: x.time_reversal, symmetries))
 
         msg = "Symmetries are:\n" + "\n".join(s.str() for s in self.symmetries)
         log_message(msg, v, 2)
@@ -408,6 +405,20 @@ class IrrepTable:
                         log_message(msg, v, 2)
                     else:
                         pass
+
+    @property
+    def u_symmetries(self):
+        '''
+        List of unitary symmetries
+        '''
+        return list(filter(lambda x: not x.time_reversal, self.symmetries))
+
+    @property
+    def au_symmetries(self):
+        '''
+        List of unitary antisymmetries
+        '''
+        return list(filter(lambda x: x.time_reversal, self.symmetries))
 
     def show(self):
         '''


### PR DESCRIPTION
- The interface for magnetic crystals in VASP has been tested with several materials
- SpaceGroup.symmetries includes unitary and antiunitary symmetries
- Create property getters SpaceGroup.u_symmetries and SpaceGroup.au_symmetries to filter unitary and antiunitary symmetries from SpaceGroup.symmetries
- Create property getters IrrepTables.u_symmetries and IrrepTables.au_symmetries to filter unitary and antiunitary symmetries from IrrepTables.symmetries

